### PR TITLE
Named token providers

### DIFF
--- a/cmd/arcade/arcade.go
+++ b/cmd/arcade/arcade.go
@@ -1,18 +1,12 @@
 package main
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"log"
-	"net/http"
 	"os"
 
 	"github.com/gin-gonic/gin"
-	"github.com/homedepot/arcade/internal/google"
 	arcadehttp "github.com/homedepot/arcade/internal/http"
-	"github.com/homedepot/arcade/internal/microsoft"
 	"github.com/homedepot/arcade/internal/middleware"
-	"github.com/homedepot/arcade/internal/rancher"
 )
 
 var (
@@ -20,24 +14,25 @@ var (
 )
 
 func init() {
-	controller := &arcadehttp.Controller{}
-
 	gin.ForceConsoleColor()
+
+	var (
+		controller arcadehttp.Controller
+		err        error
+	)
+
+	if dir := os.Getenv("ARCADE_CONFIG_DIRECTORY"); dir != "" {
+		controller, err = arcadehttp.NewController(dir)
+	} else {
+		controller, err = arcadehttp.NewDefaultController()
+	}
+
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	apiKey := mustGetenv("ARCADE_API_KEY")
 	r.Use(middleware.NewApiKeyAuth(apiKey))
-
-	controller.GoogleClient = google.NewClient()
-
-	if s := os.Getenv("RANCHER_ENABLED"); s == "TRUE" {
-		rancherClient := mustInstantiateRancherClient()
-		controller.RancherClient = rancherClient
-	}
-
-	if s := os.Getenv("MICROSOFT_ENABLED"); s == "TRUE" {
-		microsoftClient := mustInstantiateMicrosoftClient()
-		controller.MicrosoftClient = microsoftClient
-	}
 
 	r.GET("/tokens", controller.GetToken)
 }
@@ -48,51 +43,6 @@ func mustGetenv(env string) (s string) {
 	}
 
 	return
-}
-
-func mustInstantiateRancherClient() *rancher.Client {
-	url := mustGetenv("RANCHER_URL")
-	username := mustGetenv("RANCHER_USERNAME")
-	password := mustGetenv("RANCHER_PASSWORD")
-
-	rancherClient := rancher.NewClient()
-	rancherClient.WithURL(url)
-	rancherClient.WithUsername(username)
-	rancherClient.WithPassword(password)
-
-	if caCerts := os.Getenv("RANCHER_CACERTS"); caCerts != "" {
-		rootCAs, _ := x509.SystemCertPool()
-		if rootCAs == nil {
-			rootCAs = x509.NewCertPool()
-		}
-
-		rootCAs.AppendCertsFromPEM([]byte(caCerts))
-
-		t := &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: rootCAs,
-			},
-		}
-
-		rancherClient.WithTransport(t)
-	}
-
-	return rancherClient
-}
-
-func mustInstantiateMicrosoftClient() *microsoft.Client {
-	loginEndpoint := mustGetenv("MICROSOFT_LOGIN_ENDPOINT")
-	clientID := mustGetenv("MICROSOFT_CLIENT_ID")
-	clientSecret := mustGetenv("MICROSOFT_CLIENT_SECRET")
-	resource := mustGetenv("MICROSOFT_RESOURCE")
-
-	microsoftClient := microsoft.NewClient()
-	microsoftClient.WithLoginEndpoint(loginEndpoint)
-	microsoftClient.WithClientID(clientID)
-	microsoftClient.WithClientSecret(clientSecret)
-	microsoftClient.WithResource(resource)
-
-	return microsoftClient
 }
 
 // Run arcade on port 1982.

--- a/internal/http/controller.go
+++ b/internal/http/controller.go
@@ -71,6 +71,10 @@ func NewController(dir string) (Controller, error) {
 		return controller, err
 	}
 
+	if len(files) == 0 {
+		return controller, fmt.Errorf("no token providers found in directory: %s", dir)
+	}
+
 	for _, f := range files {
 		if !f.IsDir() {
 			path := filepath.Join(dir, f.Name())

--- a/internal/http/controller.go
+++ b/internal/http/controller.go
@@ -1,10 +1,182 @@
 package http
 
-import "github.com/homedepot/arcade/pkg/provider"
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/homedepot/arcade/internal/google"
+	"github.com/homedepot/arcade/internal/microsoft"
+	"github.com/homedepot/arcade/internal/rancher"
+)
+
+const (
+	ProviderTypeRancher   = "rancher"
+	ProviderTypeMicrosoft = "microsoft"
+	ProviderTypeGoogle    = "google"
+)
 
 // Controller holds clients used to grab tokens.
 type Controller struct {
-	GoogleClient    provider.Client
-	MicrosoftClient provider.Client
-	RancherClient   provider.Client
+	Tokenizers map[string]Tokenizer
+}
+
+// Tokenizer defines the interface for a client that can retrieve a token.
+type Tokenizer interface {
+	Token(context.Context) (string, error)
+}
+
+// Provider defines the token provider configuration.
+type Provider struct {
+	// General config.
+	Type string `json:"type"`
+	Name string `json:"name"`
+	// Rancher config.
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	RootCA   string `json:"rootCA,omitempty"`
+	URL      string `json:"url,omitempty"`
+	// Microsoft config.
+	ClientID      string `json:"clientId,omitempty"`
+	ClientSecret  string `json:"clientSecret,omitempty"`
+	Resource      string `json:"resource,omitempty"`
+	LoginEndpoint string `json:"loginEndpoint,omitempty"`
+}
+
+var (
+	defaultConfigDir = "/secret/arcade/providers"
+)
+
+// NewDefaultController creates a Controller with the default
+// configuration directory.
+func NewDefaultController() (Controller, error) {
+	return NewController(defaultConfigDir)
+}
+
+// NewController creates a Controller, retrieving the token providers'
+// configuration files from the given directory.
+func NewController(dir string) (Controller, error) {
+	controller := Controller{
+		Tokenizers: map[string]Tokenizer{},
+	}
+
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return controller, err
+	}
+
+	for _, f := range files {
+		if !f.IsDir() {
+			path := filepath.Join(dir, f.Name())
+
+			// Handle symlinks for ConfigMaps.
+			ln, err := filepath.EvalSymlinks(path)
+			if err == nil {
+				path = ln
+			}
+
+			b, err := ioutil.ReadFile(path)
+			if err != nil {
+				// Just continue if we're not able to read the 'file' as the file might be a symlink to
+				// a dir when using kubernetes ConfigMaps, for example:
+				//
+				// drwxr-xr-x    2 root     root          4096 Oct  8 20:38 ..2020_10_08_20_38_50.434422700
+				// lrwxrwxrwx    1 root     root            31 Oct  8 20:38 ..data -> ..2020_10_08_20_38_50.434422700
+				continue
+			}
+
+			p := Provider{}
+
+			err = json.Unmarshal(b, &p)
+			if err != nil {
+				return controller, err
+			}
+
+			if p.Name == "" {
+				return controller, fmt.Errorf("no \"name\" found in token provider config file %s", path)
+			}
+
+			for name := range controller.Tokenizers {
+				if strings.EqualFold(p.Name, name) {
+					return controller, fmt.Errorf("duplicate token provider listed: %s", p.Name)
+				}
+			}
+
+			t := p.Type
+			switch t {
+			case ProviderTypeGoogle:
+				client := google.NewClient()
+				controller.Tokenizers[p.Name] = client
+			case ProviderTypeMicrosoft:
+				if p.ClientID == "" {
+					return controller, fmt.Errorf("microsoft token provider file %s missing required \"clientId\" attribute", p.Name)
+				}
+
+				if p.ClientSecret == "" {
+					return controller, fmt.Errorf("microsoft token provider file %s missing required \"clientSecret\" attribute", p.Name)
+				}
+
+				if p.Resource == "" {
+					return controller, fmt.Errorf("microsoft token provider file %s missing required \"resource\" attribute", p.Name)
+				}
+
+				if p.LoginEndpoint == "" {
+					return controller, fmt.Errorf("microsoft token provider file %s missing required \"loginEndpoint\" attribute", p.Name)
+				}
+
+				client := microsoft.NewClient()
+				client.WithClientID(p.ClientID)
+				client.WithClientSecret(p.ClientSecret)
+				client.WithResource(p.Resource)
+				client.WithLoginEndpoint(p.LoginEndpoint)
+				controller.Tokenizers[p.Name] = client
+			case ProviderTypeRancher:
+				if p.Username == "" {
+					return controller, fmt.Errorf("rancher token provider file %s missing required \"username\" attribute", p.Name)
+				}
+
+				if p.Password == "" {
+					return controller, fmt.Errorf("rancher token provider file %s missing required \"password\" attribute", p.Name)
+				}
+
+				if p.URL == "" {
+					return controller, fmt.Errorf("rancher token provider file %s missing required \"url\" attribute", p.Name)
+				}
+
+				client := rancher.NewClient()
+				// If there's a rootCA, then add to HTTP transport
+				if p.RootCA != "" {
+					rootCAs, _ := x509.SystemCertPool()
+					if rootCAs == nil {
+						rootCAs = x509.NewCertPool()
+					}
+
+					rootCAs.AppendCertsFromPEM([]byte(p.RootCA))
+
+					t := &http.Transport{
+						TLSClientConfig: &tls.Config{
+							RootCAs: rootCAs,
+						},
+					}
+
+					client.WithTransport(t)
+				}
+
+				client.WithURL(p.URL)
+				client.WithUsername(p.Username)
+				client.WithPassword(p.Password)
+				controller.Tokenizers[p.Name] = client
+			default:
+				return controller, fmt.Errorf("unsupported token provider type: %s", p.Type)
+			}
+		}
+	}
+
+	return controller, nil
 }

--- a/internal/http/controller_test.go
+++ b/internal/http/controller_test.go
@@ -37,6 +37,22 @@ var _ = Describe("Controller", func() {
 			})
 		})
 
+		When("no files exist", func() {
+			BeforeEach(func() {
+				dir = "empty-dir"
+				_ = os.Mkdir(dir, 0666)
+			})
+
+			AfterEach(func() {
+				os.Remove(dir)
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("no token providers found in directory: empty-dir"))
+			})
+		})
+
 		When("a file exists with bad json", func() {
 			var tmpFile *os.File
 

--- a/internal/http/controller_test.go
+++ b/internal/http/controller_test.go
@@ -1,0 +1,275 @@
+package http_test
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+
+	arcadehttp "github.com/homedepot/arcade/internal/http"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Controller", func() {
+	var (
+		err error
+		dir string
+	)
+
+	BeforeEach(func() {
+		dir = "test"
+		log.SetOutput(ioutil.Discard)
+	})
+
+	Describe("#NewController", func() {
+		JustBeforeEach(func() {
+			_, err = arcadehttp.NewController(dir)
+		})
+
+		When("the directory does not exist", func() {
+			BeforeEach(func() {
+				dir = "i-dont-exist"
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("open i-dont-exist: no such file or directory"))
+			})
+		})
+
+		When("a file exists with bad json", func() {
+			var tmpFile *os.File
+
+			BeforeEach(func() {
+				tmpFile, err = ioutil.TempFile("test", "cred*.json")
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("unexpected end of JSON input"))
+			})
+		})
+
+		When("a file exists without specifying a name", func() {
+			var tmpFile *os.File
+
+			BeforeEach(func() {
+				tmpFile, err = ioutil.TempFile("test", "provider*.json")
+				_, err = tmpFile.WriteString("{}")
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix("no \"name\" found in token provider config file test/provider"))
+			})
+		})
+
+		When("a duplicate credential exists", func() {
+			var tmpFile *os.File
+
+			BeforeEach(func() {
+				tmpFile, err = ioutil.TempFile("test", "provider*.json")
+				_, err = tmpFile.WriteString(`{
+					"name": "google-test"
+				}`)
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix("duplicate token provider listed: google-test"))
+			})
+		})
+
+		When("a microsoft token provider does not set the clientId", func() {
+			var tmpFile *os.File
+
+			BeforeEach(func() {
+				tmpFile, err = ioutil.TempFile("test", "provider*.json")
+				_, err = tmpFile.WriteString(`{
+          "type": "microsoft",
+					"name": "test",
+					"clientSecret": "clientSecret",
+					"resource": "resource",
+					"loginEndpoint": "loginEndpoint"
+				}`)
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix(`microsoft token provider file test missing required "clientId" attribute`))
+			})
+		})
+
+		When("a microsoft token provider does not set the clientSecret", func() {
+			var tmpFile *os.File
+
+			BeforeEach(func() {
+				tmpFile, err = ioutil.TempFile("test", "provider*.json")
+				_, err = tmpFile.WriteString(`{
+          "type": "microsoft",
+					"name": "test",
+					"clientId": "clientId",
+					"resource": "resource",
+					"loginEndpoint": "loginEndpoint"
+				}`)
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix(`microsoft token provider file test missing required "clientSecret" attribute`))
+			})
+		})
+
+		When("a microsoft token provider does not set the resource", func() {
+			var tmpFile *os.File
+
+			BeforeEach(func() {
+				tmpFile, err = ioutil.TempFile("test", "provider*.json")
+				_, err = tmpFile.WriteString(`{
+          "type": "microsoft",
+					"name": "test",
+					"clientId": "clientId",
+					"clientSecret": "clientSecret",
+					"loginEndpoint": "loginEndpoint"
+				}`)
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix(`microsoft token provider file test missing required "resource" attribute`))
+			})
+		})
+
+		When("a microsoft token provider does not set the loginEndpoint", func() {
+			var tmpFile *os.File
+
+			BeforeEach(func() {
+				tmpFile, err = ioutil.TempFile("test", "provider*.json")
+				_, err = tmpFile.WriteString(`{
+          "type": "microsoft",
+					"name": "test",
+					"clientId": "clientId",
+					"clientSecret": "clientSecret",
+					"resource": "resource"
+				}`)
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix(`microsoft token provider file test missing required "loginEndpoint" attribute`))
+			})
+		})
+
+		When("a rancher token provider does not set the username", func() {
+			var tmpFile *os.File
+
+			BeforeEach(func() {
+				tmpFile, err = ioutil.TempFile("test", "provider*.json")
+				_, err = tmpFile.WriteString(`{
+          "type": "rancher",
+					"name": "test",
+					"password": "password",
+					"url": "url"
+				}`)
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix(`rancher token provider file test missing required "username" attribute`))
+			})
+		})
+
+		When("a rancher token provider does not set the password", func() {
+			var tmpFile *os.File
+
+			BeforeEach(func() {
+				tmpFile, err = ioutil.TempFile("test", "provider*.json")
+				_, err = tmpFile.WriteString(`{
+          "type": "rancher",
+					"name": "test",
+					"username": "username",
+					"url": "url"
+				}`)
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix(`rancher token provider file test missing required "password" attribute`))
+			})
+		})
+
+		When("a rancher token provider does not set the url", func() {
+			var tmpFile *os.File
+
+			BeforeEach(func() {
+				tmpFile, err = ioutil.TempFile("test", "provider*.json")
+				_, err = tmpFile.WriteString(`{
+          "type": "rancher",
+					"name": "test",
+					"username": "username",
+					"password": "password"
+				}`)
+				Expect(err).To(BeNil())
+			})
+
+			AfterEach(func() {
+				os.Remove(tmpFile.Name())
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HavePrefix(`rancher token provider file test missing required "url" attribute`))
+			})
+		})
+
+		When("it succeeds", func() {
+			It("succeeds", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+})

--- a/internal/http/test/google-test.json
+++ b/internal/http/test/google-test.json
@@ -1,0 +1,4 @@
+{
+  "name": "google-test",
+  "type": "google"
+}

--- a/internal/http/test/microsoft-test-1.json
+++ b/internal/http/test/microsoft-test-1.json
@@ -1,0 +1,8 @@
+{
+  "name": "microsoft-test-1",
+  "type": "microsoft",
+  "clientId": "microsoft-test-1-client-id",
+  "clientSecret": "microsoft-test-1-client-secret",
+  "resource": "microsoft-test-1-resource",
+  "loginEndpoint": "microsoft-test-1-loginEndpoint"
+}

--- a/internal/http/test/microsoft-test-2.json
+++ b/internal/http/test/microsoft-test-2.json
@@ -1,0 +1,8 @@
+{
+  "name": "microsoft-test-2",
+  "type": "microsoft",
+  "clientId": "microsoft-test-2-client-id",
+  "clientSecret": "microsoft-test-2-client-secret",
+  "resource": "microsoft-test-2-resource",
+  "loginEndpoint": "microsoft-test-2-loginEndpoint"
+}

--- a/internal/http/test/rancher-test-1.json
+++ b/internal/http/test/rancher-test-1.json
@@ -1,0 +1,7 @@
+{
+  "name": "rancher-test-1",
+  "type": "rancher",
+  "username": "rancher-test-1-username",
+  "password": "rancher-test-1-password",
+  "url": "rancher-test-1-url"
+}

--- a/internal/http/test/rancher-test-2.json
+++ b/internal/http/test/rancher-test-2.json
@@ -1,0 +1,7 @@
+{
+  "name": "rancher-test-2",
+  "type": "rancher",
+  "username": "rancher-test-2-username",
+  "password": "rancher-test-2-password",
+  "url": "rancher-test-2-url"
+}

--- a/internal/http/token.go
+++ b/internal/http/token.go
@@ -11,57 +11,18 @@ import (
 // GetToken returns a new access token for a given provider.
 func (ctl *Controller) GetToken(c *gin.Context) {
 	provider := c.Query("provider")
+	if provider == "" {
+		provider = "google"
+	}
 
-	switch provider {
-	case "google", "":
-		ctl.getGoogleToken(c)
-	case "microsoft":
-		ctl.getMicrosoftToken(c)
-	case "rancher":
-		ctl.getRancherToken(c)
-	default:
+	tokenizer, ok := ctl.Tokenizers[provider]
+	if !ok {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Unsupported token provider: %s", provider)})
 
 		return
 	}
-}
 
-func (ctl *Controller) getGoogleToken(c *gin.Context) {
-	t, err := ctl.GoogleClient.Token(context.Background())
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{"token": t})
-}
-
-func (ctl *Controller) getMicrosoftToken(c *gin.Context) {
-	if ctl.MicrosoftClient == nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "token provider not configured: microsoft"})
-
-		return
-	}
-
-	t, err := ctl.MicrosoftClient.Token(c)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-
-		return
-	}
-
-	c.JSON(http.StatusOK, gin.H{"token": t})
-}
-
-func (ctl *Controller) getRancherToken(c *gin.Context) {
-	if ctl.RancherClient == nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "token provider not configured: rancher"})
-
-		return
-	}
-
-	t, err := ctl.RancherClient.Token(c)
+	t, err := tokenizer.Token(context.Background())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 

--- a/internal/http/token_test.go
+++ b/internal/http/token_test.go
@@ -46,9 +46,11 @@ var _ = Describe("Token", func() {
 		gin.SetMode(gin.ReleaseMode)
 		// Setup the controller.
 		controller = &arcadehttp.Controller{
-			GoogleClient:    fakeGoogleClient,
-			MicrosoftClient: fakeMicrosoftClient,
-			RancherClient:   fakeRancherClient,
+			Tokenizers: map[string]arcadehttp.Tokenizer{
+				"google":    fakeGoogleClient,
+				"microsoft": fakeMicrosoftClient,
+				"rancher":   fakeRancherClient,
+			},
 		}
 		// Setup the server.
 		r := gin.New()
@@ -132,14 +134,14 @@ var _ = Describe("Token", func() {
 
 		When("microsoft is not a configured provider", func() {
 			BeforeEach(func() {
-				controller.MicrosoftClient = nil
+				delete(controller.Tokenizers, "microsoft")
 			})
 
 			It("returns a bad request error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				b, _ := ioutil.ReadAll(res.Body)
 				_ = json.Unmarshal(b, &tokens)
-				Expect(tokens.Error).To(Equal("token provider not configured: microsoft"))
+				Expect(tokens.Error).To(Equal("Unsupported token provider: microsoft"))
 			})
 		})
 
@@ -173,14 +175,14 @@ var _ = Describe("Token", func() {
 
 		When("rancher is not a configured provider", func() {
 			BeforeEach(func() {
-				controller.RancherClient = nil
+				delete(controller.Tokenizers, "rancher")
 			})
 
 			It("returns a bad request error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				b, _ := ioutil.ReadAll(res.Body)
 				_ = json.Unmarshal(b, &tokens)
-				Expect(tokens.Error).To(Equal("token provider not configured: rancher"))
+				Expect(tokens.Error).To(Equal("Unsupported token provider: rancher"))
 			})
 		})
 


### PR DESCRIPTION
Enables multiple rancher or microsoft token providers by replacing the `RANCHER_*` and `MICROSOFT_*` environment variables with token provider configuration JSON files located in a directory, with the form
```json
{
  "name": ""  // Name of the token provider, must be unique across all providers
  "type": ""   // Provider type, possible values are "google", "microsoft", "rancher"
  // provider type specific attributes
  ...
 }
 ```
 At start up, arcade will process each JSON file and create the appropriate token client.
 
 To get a token, call the `tokens` endpoint specifying the provider's name.  For example, if this is one of the configuration files
 ```json
 {
  "name": "rancher-example",
  "type": "rancher",
  "username": "username".
  "password": "password",
  "url": "https://rancher.example.com/login"
}
```
then to get the token for it, call
```
GET /tokens?provider=rancher-example
```

**Note:** While google is still the default when no provider is specified on the tokens endpoint, you need to create a 'google' configuration file.
```json
{
  "name": "google",
  "type": "google"
}
```
Without a google configuration file, no token client is created for google, which is different behavior than before.