### PR TITLE
Localize tokens to client instance

### DIFF
--- a/internal/rancher/payload_test.go
+++ b/internal/rancher/payload_test.go
@@ -32,3 +32,13 @@ const payloadKubeconfigToken = `{
   "userPrincipal": "map[metadata:map[creationTimestamp:<nil>]]",
   "uuid": "bf897e53-3cb3-49d0-af44-09343f75ec2e"
 }`
+
+const payloadKubeconfigTokenCached = `{
+	"expiresAt": "9999-12-31T00:00:00Z",
+	"token": "fake.token.cached"
+}`
+
+const payloadKubeconfigTokenAnother = `{
+	"expiresAt": "2999-01-01T00:00:00Z",
+	"token": "another.token"
+}`


### PR DESCRIPTION
Localize cached token to the client for provider types that can have multiple instances
- microsoft
- rancher

Maintaining the cached token variables at the package level means that each client instance are sharing the same variables instead of having their own, unique set of variables.  This resulted in two different **rancher** providers, `rancher-1` and `rancher-2` returning  the same token, even though they have different URLs.

```
$ curl -H 'api-key: test' http://localhost:1982/tokens?provider=rancher-1
{"token":"kubeconfig-u-usle7wn4yu:cz8t5gwdx6bcm4pnxssv7qs2c9htzd59l99n4j5zvvtvnn652jbwtq"}

$ curl -H 'api-key: test' http://localhost:1982/tokens?provider=rancher-2
{"token":"kubeconfig-u-usle7wn4yu:cz8t5gwdx6bcm4pnxssv7qs2c9htzd59l99n4j5zvvtvnn652jbwtq"}
```