### PR TITLE
Configured requests to time out after 30 seconds

### DIFF
--- a/internal/http/controller.go
+++ b/internal/http/controller.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/homedepot/arcade/internal/google"
 	"github.com/homedepot/arcade/internal/microsoft"
@@ -17,6 +18,7 @@ import (
 )
 
 const (
+	DefaultTimeoutSeconds = 30
 	ProviderTypeRancher   = "rancher"
 	ProviderTypeMicrosoft = "microsoft"
 	ProviderTypeGoogle    = "google"
@@ -139,6 +141,7 @@ func NewController(dir string) (Controller, error) {
 				client.WithClientSecret(p.ClientSecret)
 				client.WithResource(p.Resource)
 				client.WithLoginEndpoint(p.LoginEndpoint)
+				client.WithTimeout(time.Second * DefaultTimeoutSeconds)
 				controller.Tokenizers[p.Name] = client
 			case ProviderTypeRancher:
 				if p.Username == "" {
@@ -175,6 +178,7 @@ func NewController(dir string) (Controller, error) {
 				client.WithURL(p.URL)
 				client.WithUsername(p.Username)
 				client.WithPassword(p.Password)
+				client.WithTimeout(time.Second * DefaultTimeoutSeconds)
 				controller.Tokenizers[p.Name] = client
 			default:
 				return controller, fmt.Errorf("unsupported token provider type: %s", p.Type)

--- a/internal/microsoft/client_test.go
+++ b/internal/microsoft/client_test.go
@@ -3,6 +3,7 @@ package microsoft_test
 import (
 	"context"
 	"net/http"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -28,6 +29,7 @@ var _ = Describe("Client", func() {
 		client.WithClientID("fake-client-id")
 		client.WithClientSecret("fake-client-secret")
 		client.WithResource("fake-resource")
+		client.WithTimeout(time.Second)
 	})
 
 	AfterEach(func() {
@@ -103,6 +105,17 @@ var _ = Describe("Client", func() {
 			It("returns an error", func() {
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(Equal("microsoft: error getting token: Error - requested resource not allowed"))
+			})
+		})
+
+		When("the response times out", func() {
+			BeforeEach(func() {
+				client.WithTimeout(0)
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HaveSuffix("context deadline exceeded"))
 			})
 		})
 
@@ -185,6 +198,7 @@ var _ = Describe("Client", func() {
 			anotherclient.WithClientID("another-fake-client-id")
 			anotherclient.WithClientSecret("antoher-fake-client-secret")
 			anotherclient.WithResource("anotherfake-resource")
+			anotherclient.WithTimeout(time.Second)
 
 			// Call to server for first client.
 			res = `{

--- a/internal/rancher/client_test.go
+++ b/internal/rancher/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net/http"
+	"time"
 
 	. "github.com/homedepot/arcade/internal/rancher"
 
@@ -30,6 +31,7 @@ var _ = Describe("Client", func() {
 		client.WithURL(server.URL())
 		client.WithUsername(username)
 		client.WithPassword(password)
+		client.WithTimeout(time.Second)
 	})
 
 	Describe("#NewToken", func() {
@@ -84,6 +86,17 @@ var _ = Describe("Client", func() {
 			It("returns an error", func() {
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(Equal("invalid character ';' looking for beginning of object key string"))
+			})
+		})
+
+		When("the response times out", func() {
+			BeforeEach(func() {
+				client.WithTimeout(0)
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(HaveSuffix("context deadline exceeded"))
 			})
 		})
 
@@ -198,6 +211,7 @@ var _ = Describe("Client", func() {
 				anotherclient.WithURL(server.URL())
 				anotherclient.WithUsername("another-test-user")
 				anotherclient.WithPassword("another-test-pass")
+				anotherclient.WithTimeout(time.Second)
 				json = `{"responseType": "kubeconfig","username": "another-test-user","password": "another-test-pass"}`
 				server.AppendHandlers(ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", "/"),


### PR DESCRIPTION
As advised in this [article](https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779), you should always configure  your http client to set a timeout value because the default client has a 'no timeout' policy, which can cause your requests to hang waiting for a response from a degraded backend server.

This PR sets a default timeout value of 30 seconds on token providers
- microsoft
- rancher

If a request to obtain a token from one of these providers, takes longer than 30 seconds, then the request is short-circuited and an error is returned

<img width="839" alt="image" src="https://user-images.githubusercontent.com/16955707/139243006-e86020ad-c098-426d-bcc3-9f86d1cd2479.png">
