### PR TITLE
[CN-1273]: add short expiration to client, unit tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,6 +45,6 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.41.1
+          version: v1.40
 
           args: --enable wsl --timeout 180s

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,4 +47,4 @@ jobs:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.40
 
-          args: --enable wsl --timeout 180s
+          args: --skip-files .*_test.go --enable wsl --enable misspell --timeout 180s

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,7 +37,7 @@ jobs:
       run: go test -v ./...
 
   golangci:
-    name: lint
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -45,6 +45,6 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.41.1
 
           args: --enable wsl --timeout 180s

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /arcade
 *.coverprofile
+.idea/

--- a/cmd/arcade/arcade.go
+++ b/cmd/arcade/arcade.go
@@ -32,7 +32,7 @@ func init() {
 	}
 
 	apiKey := mustGetenv("ARCADE_API_KEY")
-	r.Use(middleware.NewApiKeyAuth(apiKey))
+	r.Use(middleware.NewAPIKeyAuth(apiKey))
 
 	r.GET("/tokens", controller.GetToken)
 }

--- a/internal/http/controller.go
+++ b/internal/http/controller.go
@@ -179,10 +179,12 @@ func NewController(dir string) (Controller, error) {
 				client.WithURL(p.URL)
 				client.WithUsername(p.Username)
 				client.WithPassword(p.Password)
+				client.WithTimeout(time.Second * DefaultTimeoutSeconds)
+
 				if p.ShortExpiration > 0 {
 					client.WithShortExpiration(p.ShortExpiration)
 				}
-				client.WithTimeout(time.Second * DefaultTimeoutSeconds)
+
 				controller.Tokenizers[p.Name] = client
 			default:
 				return controller, fmt.Errorf("unsupported token provider type: %s", p.Type)

--- a/internal/http/controller.go
+++ b/internal/http/controller.go
@@ -40,10 +40,11 @@ type Provider struct {
 	Type string `json:"type"`
 	Name string `json:"name"`
 	// Rancher config.
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
-	RootCA   string `json:"rootCA,omitempty"`
-	URL      string `json:"url,omitempty"`
+	Username        string `json:"username,omitempty"`
+	Password        string `json:"password,omitempty"`
+	RootCA          string `json:"rootCA,omitempty"`
+	URL             string `json:"url,omitempty"`
+	ShortExpiration int    `json:"shortExpiration,omitempty"`
 	// Microsoft config.
 	ClientID      string `json:"clientId,omitempty"`
 	ClientSecret  string `json:"clientSecret,omitempty"`
@@ -178,6 +179,7 @@ func NewController(dir string) (Controller, error) {
 				client.WithURL(p.URL)
 				client.WithUsername(p.Username)
 				client.WithPassword(p.Password)
+				client.WithShortExpiration(p.ShortExpiration)
 				client.WithTimeout(time.Second * DefaultTimeoutSeconds)
 				controller.Tokenizers[p.Name] = client
 			default:

--- a/internal/http/controller.go
+++ b/internal/http/controller.go
@@ -180,10 +180,7 @@ func NewController(dir string) (Controller, error) {
 				client.WithUsername(p.Username)
 				client.WithPassword(p.Password)
 				client.WithTimeout(time.Second * DefaultTimeoutSeconds)
-
-				if p.ShortExpiration > 0 {
-					client.WithShortExpiration(p.ShortExpiration)
-				}
+				client.WithShortExpiration(p.ShortExpiration)
 
 				controller.Tokenizers[p.Name] = client
 			default:

--- a/internal/http/controller.go
+++ b/internal/http/controller.go
@@ -179,7 +179,9 @@ func NewController(dir string) (Controller, error) {
 				client.WithURL(p.URL)
 				client.WithUsername(p.Username)
 				client.WithPassword(p.Password)
-				client.WithShortExpiration(p.ShortExpiration)
+				if p.ShortExpiration > 0 {
+					client.WithShortExpiration(p.ShortExpiration)
+				}
 				client.WithTimeout(time.Second * DefaultTimeoutSeconds)
 				controller.Tokenizers[p.Name] = client
 			default:

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func NewApiKeyAuth(apiKey string) gin.HandlerFunc {
+func NewAPIKeyAuth(apiKey string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if c.Request.Header.Get("Api-Key") != apiKey {
 			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "bad api key"})

--- a/internal/rancher/client.go
+++ b/internal/rancher/client.go
@@ -43,7 +43,7 @@ func (c *Client) Token(ctx context.Context) (string, error) {
 	c.mux.Lock()
 	defer c.mux.Unlock()
 
-	tokenExpired := int(time.Since(c.cachedToken.Created.In(time.UTC)).Seconds()) > c.shortExpiration
+	tokenExpired := c.shortExpiration > 0 && int(time.Since(c.cachedToken.Created.In(time.UTC)).Seconds()) > c.shortExpiration
 	if time.Now().In(time.UTC).After(c.cachedToken.ExpiresAt) || c.cachedToken.Token == "" || tokenExpired {
 		k := KubeconfigToken{}
 

--- a/internal/rancher/client_test.go
+++ b/internal/rancher/client_test.go
@@ -50,6 +50,7 @@ var _ = Describe("Client", func() {
 
 			It("returns an error", func() {
 				Expect(err).ToNot(BeNil())
+				Expect(server.ReceivedRequests()).To(HaveLen(0))
 			})
 		})
 
@@ -60,6 +61,7 @@ var _ = Describe("Client", func() {
 
 			It("returns an error", func() {
 				Expect(err).ToNot(BeNil())
+				Expect(server.ReceivedRequests()).To(HaveLen(0))
 			})
 		})
 
@@ -73,6 +75,7 @@ var _ = Describe("Client", func() {
 			It("returns an error", func() {
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(Equal("error getting token: 404 Not Found"))
+				Expect(server.ReceivedRequests()).To(HaveLen(1))
 			})
 		})
 
@@ -86,6 +89,7 @@ var _ = Describe("Client", func() {
 			It("returns an error", func() {
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(Equal("invalid character ';' looking for beginning of object key string"))
+				Expect(server.ReceivedRequests()).To(HaveLen(1))
 			})
 		})
 
@@ -97,6 +101,7 @@ var _ = Describe("Client", func() {
 			It("returns an error", func() {
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(HaveSuffix("context deadline exceeded"))
+				Expect(server.ReceivedRequests()).To(HaveLen(0))
 			})
 		})
 
@@ -115,6 +120,7 @@ var _ = Describe("Client", func() {
 			It("succeeds", func() {
 				Expect(err).To(BeNil())
 				Expect(t).To(Equal("kubeconfig-u-i76rfanbw5:ltqlpxqz5hh52sxfxfbxxkk6xw7pzkh7d922cww6m9x6fjskskxwl9"))
+				Expect(server.ReceivedRequests()).To(HaveLen(1))
 			})
 		})
 
@@ -133,6 +139,7 @@ var _ = Describe("Client", func() {
 			It("succeeds", func() {
 				Expect(err).To(BeNil())
 				Expect(t).To(Equal("kubeconfig-u-i76rfanbw5:ltqlpxqz5hh52sxfxfbxxkk6xw7pzkh7d922cww6m9x6fjskskxwl9"))
+				Expect(server.ReceivedRequests()).To(HaveLen(1))
 			})
 		})
 
@@ -154,6 +161,7 @@ var _ = Describe("Client", func() {
 			It("succeeds", func() {
 				Expect(err).To(BeNil())
 				Expect(t).To(Equal("kubeconfig-u-i76rfanbw5:ltqlpxqz5hh52sxfxfbxxkk6xw7pzkh7d922cww6m9x6fjskskxwl9"))
+				Expect(server.ReceivedRequests()).To(HaveLen(1))
 			})
 		})
 
@@ -174,6 +182,7 @@ var _ = Describe("Client", func() {
 				// Second call returns cached token
 				t2, _ := client.Token(context.Background())
 				Expect(t2).To(Equal("fake.token.cached"))
+				Expect(server.ReceivedRequests()).To(HaveLen(1))
 			})
 		})
 
@@ -191,6 +200,7 @@ var _ = Describe("Client", func() {
 			It("succeeds", func() {
 				Expect(err).To(BeNil())
 				Expect(t).To(Equal("kubeconfig-u-i76rfanbw5:ltqlpxqz5hh52sxfxfbxxkk6xw7pzkh7d922cww6m9x6fjskskxwl9"))
+				Expect(server.ReceivedRequests()).To(HaveLen(1))
 			})
 		})
 
@@ -230,6 +240,7 @@ var _ = Describe("Client", func() {
 				t, err = anotherclient.Token(context.Background())
 				Expect(err).To(BeNil())
 				Expect(t).To(Equal("another.token"))
+				Expect(server.ReceivedRequests()).To(HaveLen(2))
 			})
 		})
 
@@ -262,6 +273,7 @@ var _ = Describe("Client", func() {
 				t2, err2 := client.Token(context.Background())
 				Expect(err2).To(BeNil())
 				Expect(t2).To(Equal("another.token"))
+				Expect(server.ReceivedRequests()).To(HaveLen(2))
 			})
 		})
 
@@ -288,7 +300,7 @@ var _ = Describe("Client", func() {
 				t2, err2 := client.Token(context.Background())
 				Expect(err2).To(BeNil())
 				Expect(t2).To(Equal("fake.token.cached"))
-
+				Expect(server.ReceivedRequests()).To(HaveLen(1))
 			})
 		})
 
@@ -307,8 +319,8 @@ var _ = Describe("Client", func() {
 			It("fetches a new token", func() {
 				Expect(err).To(BeNil())
 				Expect(t).To(Equal("kubeconfig-u-i76rfanbw5:ltqlpxqz5hh52sxfxfbxxkk6xw7pzkh7d922cww6m9x6fjskskxwl9"))
+				Expect(server.ReceivedRequests()).To(HaveLen(1))
 			})
 		})
-
 	})
 })

--- a/internal/rancher/client_test.go
+++ b/internal/rancher/client_test.go
@@ -279,7 +279,7 @@ var _ = Describe("Client", func() {
 
 		When("there is a shortExpiration set and it has not passed and there is a cached token", func() {
 			BeforeEach(func() {
-				client.WithShortExpiration(60)
+				client.WithShortExpiration(9223372040)
 				json := `{"responseType": "kubeconfig","username": "test-user","password": "test-pass"}`
 				server.AppendHandlers(ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", "/"),

--- a/internal/rancher/payload_test.go
+++ b/internal/rancher/payload_test.go
@@ -34,12 +34,13 @@ const payloadKubeconfigToken = `{
 }`
 
 const payloadKubeconfigTokenCached = `{
-	"created": "9999-12-31T00:00:00Z",
+  "created": "2021-03-25T10:38:18Z",
 	"expiresAt": "9999-12-31T00:00:00Z",
 	"token": "fake.token.cached"
 }`
 
 const payloadKubeconfigTokenAnother = `{
+	"created": "2012-12-31T00:00:00Z",
 	"expiresAt": "2999-01-01T00:00:00Z",
 	"token": "another.token"
 }`

--- a/internal/rancher/payload_test.go
+++ b/internal/rancher/payload_test.go
@@ -34,6 +34,7 @@ const payloadKubeconfigToken = `{
 }`
 
 const payloadKubeconfigTokenCached = `{
+	"created": "9999-12-31T00:00:00Z",
 	"expiresAt": "9999-12-31T00:00:00Z",
 	"token": "fake.token.cached"
 }`

--- a/internal/rancher/payload_test.go
+++ b/internal/rancher/payload_test.go
@@ -34,7 +34,7 @@ const payloadKubeconfigToken = `{
 }`
 
 const payloadKubeconfigTokenCached = `{
-  "created": "2021-03-25T10:38:18Z",
+  	"created": "2021-03-25T10:38:18Z",
 	"expiresAt": "9999-12-31T00:00:00Z",
 	"token": "fake.token.cached"
 }`


### PR DESCRIPTION
- adds a `shortExpiration` key for handling deleted / expired tokens 