### PR TITLE
Rancher logging and Release workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,7 @@
 name: Go
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:
@@ -23,15 +24,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
+      run: ./get-dependencies.sh
 
     - name: Build
-      run: go build -v cmd/arcade/arcade.go
+      run: ./build.sh -v
 
     - name: Test
       run: go test -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,10 @@
+name: Release
+on:
+  workflow_dispatch:
+    input:
+      name: Version
+      id: VERSION
+      type: string
+      
+jobs:
+  release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,5 +5,28 @@ on:
       version:
         type: string
         description: version to tag image
+        
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+    steps:
+      - name: Setup - checkout
+        uses: actions/checkout@v3
+        
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.13
+        id: go
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: docker
+        shell: bash    
+        run: docker/docker-build.sh -v ${VERSION}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: Release
 on:
   workflow_dispatch:
-    input:
-      name: Version
-      id: VERSION
-      type: string
-      
-jobs:
-  release:
+    inputs:
+      version:
+        type: string
+        description: version to tag image
+
+

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ Run the following commands to build and generate a token.
 ### Build
 
 ```bash
-go build cmd/arcade/arcade.go
+./get-dependencies.sh
+./build.sh
 ```
 
 ### Run

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -o errexit
+
+CGO_ENABLED=0 go build "${@}" cmd/arcade/arcade.go

--- a/cmd/arcade/arcade.go
+++ b/cmd/arcade/arcade.go
@@ -47,6 +47,7 @@ func mustGetenv(env string) (s string) {
 
 // Run arcade on port 1982.
 func main() {
+	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds | log.Lshortfile)
 	if err := r.Run(":1982"); err != nil {
 		log.Fatal(err)
 	}

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,7 +5,7 @@ set -o errexit
 # Builds the base image including the solver dependencies
 build_and_publish_image(){
     set -x
-    GOOS=linux GOARCH=amd64 go build cmd/arcade/arcade.go
+    GOOS=linux GOARCH=amd64 go build --ldflags '-extldflags "-static"' cmd/arcade/arcade.go
     GCR_TAG="oshomedepot/arcade:${TAG_VERSION}"
     docker build . -f docker/Dockerfile -t ${GCR_TAG}
     echo "Image ${GCR_TAG} built..."

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,6 +4,7 @@ set -o errexit
 
 # Builds the base image including the solver dependencies
 build_and_publish_image(){
+    set -x
     GOOS=linux GOARCH=amd64 go build cmd/arcade/arcade.go
     GCR_TAG="oshomedepot/arcade:${TAG_VERSION}"
     docker build . -f docker/Dockerfile -t ${GCR_TAG}

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -4,8 +4,9 @@ set -o errexit
 
 # Builds the base image including the solver dependencies
 build_and_publish_image(){
-    set -x
-    GOOS=linux GOARCH=amd64 go build --ldflags '-extldflags "-static"' cmd/arcade/arcade.go
+    export PATH=.:$PATH
+    get-dependencies.sh >/dev/null
+    GOOS=linux GOARCH=amd64 build.sh
     GCR_TAG="oshomedepot/arcade:${TAG_VERSION}"
     docker build . -f docker/Dockerfile -t ${GCR_TAG}
     echo "Image ${GCR_TAG} built..."

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -o errexit
+
+go get -v -t -d ./...
+if [ -f Gopkg.toml ]; then
+    curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+    dep ensure
+fi

--- a/internal/rancher/client_test.go
+++ b/internal/rancher/client_test.go
@@ -78,6 +78,34 @@ var _ = Describe("Client", func() {
 				Expect(server.ReceivedRequests()).To(HaveLen(1))
 			})
 		})
+		
+		When("the response is not 201 with response", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.RespondWith(404, "NOT FOUND"),
+				)
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("error getting token: 404 Not Found"))
+				Expect(server.ReceivedRequests()).To(HaveLen(1))
+			})
+		})
+		
+		When("the response is not 201 with response greater than 100 characters", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.RespondWith(500, "<html>Some really long message!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!</html>"),
+				)
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("error getting token: 500 Internal Server Error"))
+				Expect(server.ReceivedRequests()).To(HaveLen(1))
+			})
+		})
 
 		When("the response is invalid", func() {
 			BeforeEach(func() {


### PR DESCRIPTION
Following changes:

* cmd/arcade/arcade.go: Set Flags for logging

* internal/rancher/client.go: Add logging when getting token fails

* internal/rancher/client_test.go: Added 2 test cases to cover new code paths for logging

* build.sh: Add script to build arcade (same process can now be used manually and workflow files)

* get-dependencies.sh: Add script to get build dependencies (same process can now be used manually and workflow files)

* docker/build.sh → docker/docker-build.sh: Rename to avoid confusion with build.sh and call get-dependencies.sh and build.sh instead of duplicating logic

* .github/workflows/go.yml: Updated to call get-dependencies.sh and build.sh instead of duplicating logic

* .github/workflows/release.yml: New workflow with version parameter to build docker image